### PR TITLE
Relay Driver Symbol Rework

### DIFF
--- a/Libraries/formula_slug_symbol_library.kicad_sym
+++ b/Libraries/formula_slug_symbol_library.kicad_sym
@@ -15194,7 +15194,7 @@
 		(in_bom yes)
 		(on_board yes)
 		(property "Reference" "U"
-			(at 0.508 8.382 0)
+			(at 3.302 0.762 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15202,7 +15202,7 @@
 			)
 		)
 		(property "Value" "SZNUD3124LT1G"
-			(at 0.508 5.842 0)
+			(at 10.414 -1.016 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15210,7 +15210,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_SMD:TSOT-23_HandSoldering"
-			(at -12.7 -1.27 0)
+			(at 43.18 0 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15220,7 +15220,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.onsemi.com/pdf/datasheet/nud3124-d.pdf"
-			(at -12.7 -1.27 0)
+			(at 43.18 0 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15230,7 +15230,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 0 0 0)
+			(at -5.08 0 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15239,7 +15239,7 @@
 			)
 		)
 		(property "Digi PN" "SZNUD3124LT1GOSCT-ND"
-			(at -12.7 -1.27 0)
+			(at 43.18 0 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15248,7 +15248,7 @@
 			)
 		)
 		(property "Digi URL" "https://www.digikey.com/en/products/detail/onsemi/SZNUD3124LT1G/3063416"
-			(at -12.7 -1.27 0)
+			(at 43.18 0 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15257,7 +15257,7 @@
 			)
 		)
 		(property "MFG" "onsemi"
-			(at -12.7 -1.27 0)
+			(at 43.18 0 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15266,7 +15266,7 @@
 			)
 		)
 		(property "MFG PN" "SZNUD3124LT1G"
-			(at -12.7 -1.27 0)
+			(at 43.18 0 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15274,7 +15274,7 @@
 				(hide yes)
 			)
 		)
-		(property "ki_keywords" "SZNUD3124LT1G"
+		(property "ki_keywords" "SZNUD3124LT1G Relay Driver"
 			(at 0 0 0)
 			(effects
 				(font
@@ -15292,10 +15292,541 @@
 				(hide yes)
 			)
 		)
+		(symbol "SZNUD3124LT1G_0_1"
+			(polyline
+				(pts
+					(xy -16.256 -4.318) (xy -16.256 -4.826) (xy -14.224 -4.826)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -16.002 -3.556) (xy -15.24 -4.826) (xy -14.478 -3.556) (xy -16.002 -3.556)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center -15.24 0)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -15.24 -6.35) (xy -15.24 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -15.24 -6.35) (xy -12.7 -6.35)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -14.478 -2.794) (xy -15.24 -1.524) (xy -16.002 -2.794) (xy -14.478 -2.794)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -14.224 -2.032) (xy -14.224 -1.524) (xy -16.256 -1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(rectangle
+				(start -13.462 -5.08)
+				(end -11.938 -1.524)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -12.7 0)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -12.7 0) (xy -12.7 -1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -12.7 0) (xy -15.24 0) (xy -17.78 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -12.7 -5.08) (xy -12.7 -6.35)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -12.7 -6.35)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -12.7 -6.35) (xy -5.08 -6.35) (xy 0 -6.35)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -10.922 0) (xy -12.7 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(rectangle
+				(start -10.9095 0.762)
+				(end -7.3535 -0.762)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -7.366 0) (xy -5.08 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -6.096 2.032) (xy -6.096 1.524) (xy -4.064 1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -6.096 -4.318) (xy -6.096 -4.826) (xy -4.064 -4.826)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.842 2.794) (xy -5.08 1.524) (xy -4.318 2.794) (xy -5.842 2.794)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.842 -3.556) (xy -5.08 -4.826) (xy -4.318 -3.556) (xy -5.842 -3.556)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 6.35) (xy 0 6.35)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -5.08 0)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 0) (xy -5.08 6.35)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -5.08 -6.35)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 -6.35) (xy -5.08 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.318 3.556) (xy -5.08 4.826) (xy -5.842 3.556) (xy -4.318 3.556)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.318 -2.794) (xy -5.08 -1.524) (xy -5.842 -2.794) (xy -4.318 -2.794)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.064 4.318) (xy -4.064 4.826) (xy -6.096 4.826)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.064 -2.032) (xy -4.064 -1.524) (xy -6.096 -1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -2.286 2.032) (xy -2.286 -2.032)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -2.286 0) (xy -5.08 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 2.286) (xy -1.778 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 0.508) (xy -1.778 -0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 -1.27) (xy -1.778 -2.286)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 -1.778) (xy 0.762 -1.778) (xy 0.762 1.778) (xy -1.778 1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.524 0) (xy -0.508 0.381) (xy -0.508 -0.381) (xy -1.524 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 7.62) (xy 0 1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 0 6.35)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 0 1.778)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 0 -1.778)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 0 -6.35)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -7.62) (xy 0 0) (xy -1.778 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.254 0.508) (xy 0.381 0.381) (xy 1.143 0.381) (xy 1.27 0.254)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 0.381) (xy 0.381 -0.254) (xy 1.143 -0.254) (xy 0.762 0.381)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
 		(symbol "SZNUD3124LT1G_1_1"
 			(rectangle
-				(start -5.08 2.54)
-				(end 2.54 -2.54)
+				(start -17.78 7.62)
+				(end 2.54 -7.62)
 				(stroke
 					(width 0)
 					(type solid)
@@ -15305,9 +15836,9 @@
 				)
 			)
 			(pin input line
-				(at -8.89 0 0)
-				(length 3.81)
-				(name "1"
+				(at -20.32 0 0)
+				(length 2.54)
+				(name "~"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -15323,9 +15854,9 @@
 				)
 			)
 			(pin unspecified line
-				(at 6.35 1.27 180)
-				(length 3.81)
-				(name "3"
+				(at 0 10.16 270)
+				(length 2.54)
+				(name "~"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -15341,9 +15872,9 @@
 				)
 			)
 			(pin unspecified line
-				(at 6.35 -1.27 180)
-				(length 3.81)
-				(name "2"
+				(at 0 -10.16 90)
+				(length 2.54)
+				(name "~"
 					(effects
 						(font
 							(size 1.27 1.27)

--- a/Libraries/formula_slug_symbol_library.kicad_sym
+++ b/Libraries/formula_slug_symbol_library.kicad_sym
@@ -15186,7 +15186,7 @@
 		)
 		(embedded_fonts no)
 	)
-	(symbol "SZNUD3124LT1G"
+	(symbol "SZNUD3124DMT1G"
 		(pin_names
 			(offset 0.254)
 		)
@@ -15201,7 +15201,7 @@
 				)
 			)
 		)
-		(property "Value" "SZNUD3124LT1G"
+		(property "Value" "SZNUD3124DMT1G"
 			(at 10.414 -1.016 0)
 			(effects
 				(font
@@ -15209,8 +15209,8 @@
 				)
 			)
 		)
-		(property "Footprint" "Package_TO_SOT_SMD:TSOT-23_HandSoldering"
-			(at 43.18 0 0)
+		(property "Footprint" "Package_TO_SOT_SMD:SC-74-6_1.55x2.9mm_P0.95mm"
+			(at 26.924 16.002 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15220,7 +15220,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.onsemi.com/pdf/datasheet/nud3124-d.pdf"
-			(at 43.18 0 0)
+			(at 32.258 10.922 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15229,8 +15229,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" ""
-			(at -5.08 0 0)
+		(property "Description" "Relay Driver (Dual Case)"
+			(at 16.764 18.542 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15238,8 +15238,8 @@
 				(hide yes)
 			)
 		)
-		(property "Digi PN" "SZNUD3124LT1GOSCT-ND"
-			(at 43.18 0 0)
+		(property "Digi PN" "SZNUD3124DMT1GOSCT-ND"
+			(at 18.034 21.082 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15247,8 +15247,8 @@
 				(hide yes)
 			)
 		)
-		(property "Digi URL" "https://www.digikey.com/en/products/detail/onsemi/SZNUD3124LT1G/3063416"
-			(at 43.18 0 0)
+		(property "Digi URL" "https://www.digikey.com/en/products/detail/onsemi/SZNUD3124DMT1G/3063415"
+			(at 43.942 13.462 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15257,7 +15257,7 @@
 			)
 		)
 		(property "MFG" "onsemi"
-			(at 43.18 0 0)
+			(at 8.128 8.382 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15265,8 +15265,8 @@
 				(hide yes)
 			)
 		)
-		(property "MFG PN" "SZNUD3124LT1G"
-			(at 43.18 0 0)
+		(property "MFG PN" "SZNUD3124DMT1G"
+			(at 13.462 23.622 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15274,7 +15274,7 @@
 				(hide yes)
 			)
 		)
-		(property "ki_keywords" "SZNUD3124LT1G Relay Driver"
+		(property "ki_keywords" "SZNUD3124DMT1G Relay Driver"
 			(at 0 0 0)
 			(effects
 				(font
@@ -15283,31 +15283,10 @@
 				(hide yes)
 			)
 		)
-		(property "ki_fp_filters" "SOT-23_TO-236_318_AT_OSI SOT-23_TO-236_318_AT_OSI-M SOT-23_TO-236_318_AT_OSI-L"
-			(at 0 0 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(symbol "SZNUD3124LT1G_0_1"
+		(symbol "SZNUD3124DMT1G_0_1"
 			(polyline
 				(pts
-					(xy -16.256 -4.318) (xy -16.256 -4.826) (xy -14.224 -4.826)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -16.002 -3.556) (xy -15.24 -4.826) (xy -14.478 -3.556) (xy -16.002 -3.556)
+					(xy -11.684 -2.54) (xy -11.176 -3.302) (xy -10.668 -2.54) (xy -11.684 -2.54)
 				)
 				(stroke
 					(width 0)
@@ -15317,8 +15296,20 @@
 					(type outline)
 				)
 			)
+			(polyline
+				(pts
+					(xy -11.684 -3.048) (xy -11.684 -3.302) (xy -10.668 -3.302)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
 			(circle
-				(center -15.24 0)
+				(center -11.176 0)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15330,7 +15321,7 @@
 			)
 			(polyline
 				(pts
-					(xy -15.24 -6.35) (xy -15.24 0)
+					(xy -11.176 -4.318) (xy -11.176 0)
 				)
 				(stroke
 					(width 0)
@@ -15342,7 +15333,7 @@
 			)
 			(polyline
 				(pts
-					(xy -15.24 -6.35) (xy -12.7 -6.35)
+					(xy -11.176 -4.318) (xy 0 -4.318)
 				)
 				(stroke
 					(width 0)
@@ -15354,8 +15345,42 @@
 			)
 			(polyline
 				(pts
-					(xy -14.478 -2.794) (xy -15.24 -1.524) (xy -16.002 -2.794) (xy -14.478 -2.794)
+					(xy -10.668 -1.27) (xy -10.668 -1.016) (xy -11.684 -1.016)
 				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -10.668 -1.778) (xy -11.176 -1.016) (xy -11.684 -1.778) (xy -10.668 -1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.906 -1.016)
+				(end -8.89 -3.302)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -9.398 0)
+				(radius 0.254)
 				(stroke
 					(width 0)
 					(type default)
@@ -15366,7 +15391,54 @@
 			)
 			(polyline
 				(pts
-					(xy -14.224 -2.032) (xy -14.224 -1.524) (xy -16.256 -1.524)
+					(xy -9.398 0) (xy -9.398 -1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -9.398 -4.064) (xy -9.398 -3.302)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -9.398 -4.318)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -8.89 0) (xy -12.7 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -8.89 0) (xy -8.382 0)
 				)
 				(stroke
 					(width 0)
@@ -15377,101 +15449,8 @@
 				)
 			)
 			(rectangle
-				(start -13.462 -5.08)
-				(end -11.938 -1.524)
-				(stroke
-					(width 0.2032)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(circle
-				(center -12.7 0)
-				(radius 0.254)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type outline)
-				)
-			)
-			(polyline
-				(pts
-					(xy -12.7 0) (xy -12.7 -1.524)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -12.7 0) (xy -15.24 0) (xy -17.78 0)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -12.7 -5.08) (xy -12.7 -6.35)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(circle
-				(center -12.7 -6.35)
-				(radius 0.254)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type outline)
-				)
-			)
-			(polyline
-				(pts
-					(xy -12.7 -6.35) (xy -5.08 -6.35) (xy 0 -6.35)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -10.922 0) (xy -12.7 0)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(rectangle
-				(start -10.9095 0.762)
-				(end -7.3535 -0.762)
+				(start -8.382 0.508)
+				(end -6.096 -0.508)
 				(stroke
 					(width 0.2032)
 					(type default)
@@ -15482,43 +15461,7 @@
 			)
 			(polyline
 				(pts
-					(xy -7.366 0) (xy -5.08 0)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -6.096 2.032) (xy -6.096 1.524) (xy -4.064 1.524)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -6.096 -4.318) (xy -6.096 -4.826) (xy -4.064 -4.826)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -5.842 2.794) (xy -5.08 1.524) (xy -4.318 2.794) (xy -5.842 2.794)
+					(xy -5.588 1.778) (xy -5.08 1.016) (xy -4.572 1.778) (xy -5.588 1.778)
 				)
 				(stroke
 					(width 0)
@@ -15530,7 +15473,19 @@
 			)
 			(polyline
 				(pts
-					(xy -5.842 -3.556) (xy -5.08 -4.826) (xy -4.318 -3.556) (xy -5.842 -3.556)
+					(xy -5.588 1.27) (xy -5.588 1.016) (xy -4.572 1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.588 -2.54) (xy -5.08 -3.302) (xy -4.572 -2.54) (xy -5.588 -2.54)
 				)
 				(stroke
 					(width 0)
@@ -15542,7 +15497,19 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 6.35) (xy 0 6.35)
+					(xy -5.588 -3.048) (xy -5.588 -3.302) (xy -4.572 -3.302)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 4.318) (xy 0 4.318)
 				)
 				(stroke
 					(width 0)
@@ -15565,7 +15532,31 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 0) (xy -5.08 6.35)
+					(xy -5.08 0) (xy -6.096 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 0) (xy -5.08 4.318)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 -4.064) (xy -5.08 0.254)
 				)
 				(stroke
 					(width 0)
@@ -15576,7 +15567,7 @@
 				)
 			)
 			(circle
-				(center -5.08 -6.35)
+				(center -5.08 -4.318)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15588,7 +15579,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 -6.35) (xy -5.08 0)
+					(xy -4.572 3.048) (xy -4.572 3.302) (xy -5.588 3.302)
 				)
 				(stroke
 					(width 0)
@@ -15600,7 +15591,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.318 3.556) (xy -5.08 4.826) (xy -5.842 3.556) (xy -4.318 3.556)
+					(xy -4.572 2.54) (xy -5.08 3.302) (xy -5.588 2.54) (xy -4.572 2.54)
 				)
 				(stroke
 					(width 0)
@@ -15612,7 +15603,19 @@
 			)
 			(polyline
 				(pts
-					(xy -4.318 -2.794) (xy -5.08 -1.524) (xy -5.842 -2.794) (xy -4.318 -2.794)
+					(xy -4.572 -1.27) (xy -4.572 -1.016) (xy -5.588 -1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.572 -1.778) (xy -5.08 -1.016) (xy -5.588 -1.778) (xy -4.572 -1.778)
 				)
 				(stroke
 					(width 0)
@@ -15620,30 +15623,6 @@
 				)
 				(fill
 					(type outline)
-				)
-			)
-			(polyline
-				(pts
-					(xy -4.064 4.318) (xy -4.064 4.826) (xy -6.096 4.826)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -4.064 -2.032) (xy -4.064 -1.524) (xy -6.096 -1.524)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
 				)
 			)
 			(polyline
@@ -15732,7 +15711,7 @@
 			)
 			(polyline
 				(pts
-					(xy 0 7.62) (xy 0 1.778)
+					(xy 0 5.08) (xy 0 1.778)
 				)
 				(stroke
 					(width 0)
@@ -15743,7 +15722,7 @@
 				)
 			)
 			(circle
-				(center 0 6.35)
+				(center 0 4.318)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15776,7 +15755,7 @@
 				)
 			)
 			(circle
-				(center 0 -6.35)
+				(center 0 -4.318)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15788,7 +15767,768 @@
 			)
 			(polyline
 				(pts
-					(xy 0 -7.62) (xy 0 0) (xy -1.778 0)
+					(xy 0 -5.08) (xy 0 0) (xy -1.778 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.254 0.508) (xy 0.381 0.381) (xy 1.143 0.381) (xy 1.27 0.254)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.762 0.381) (xy 0.381 -0.254) (xy 1.143 -0.254) (xy 0.762 0.381)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "SZNUD3124DMT1G_1_1"
+			(rectangle
+				(start -12.7 5.08)
+				(end 1.524 -5.08)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -15.24 0 0)
+				(length 2.54)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin unspecified line
+				(at 0 7.62 270)
+				(length 2.54)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin unspecified line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "SZNUD3124DMT1G_2_1"
+			(rectangle
+				(start -12.7 5.08)
+				(end 1.524 -5.08)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -15.24 0 0)
+				(length 2.54)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin unspecified line
+				(at 0 7.62 270)
+				(length 2.54)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin unspecified line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "~"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "SZNUD3124LT1G"
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 3.302 0.762 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SZNUD3124LT1G"
+			(at 10.414 -1.016 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:TSOT-23_HandSoldering"
+			(at 26.924 16.002 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pdf/datasheet/nud3124-d.pdf"
+			(at 32.258 10.922 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Relay Driver"
+			(at 10.668 18.542 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Digi PN" "SZNUD3124LT1GOSCT-ND"
+			(at 17.272 21.082 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Digi URL" "https://www.digikey.com/en/products/detail/onsemi/SZNUD3124LT1G/3063416"
+			(at 43.942 13.462 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG" "onsemi"
+			(at 8.382 8.382 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG PN" "SZNUD3124LT1G"
+			(at 12.7 23.622 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "SZNUD3124LT1G Relay Driver"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "SOT-23_TO-236_318_AT_OSI SOT-23_TO-236_318_AT_OSI-M SOT-23_TO-236_318_AT_OSI-L"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "SZNUD3124LT1G_0_1"
+			(polyline
+				(pts
+					(xy -11.684 -2.54) (xy -11.176 -3.302) (xy -10.668 -2.54) (xy -11.684 -2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -11.684 -3.048) (xy -11.684 -3.302) (xy -10.668 -3.302)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -11.176 0)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -11.176 -4.318) (xy -11.176 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -11.176 -4.318) (xy 0 -4.318)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -10.668 -1.27) (xy -10.668 -1.016) (xy -11.684 -1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -10.668 -1.778) (xy -11.176 -1.016) (xy -11.684 -1.778) (xy -10.668 -1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.906 -1.016)
+				(end -8.89 -3.302)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -9.398 0)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -9.398 0) (xy -9.398 -1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -9.398 -4.064) (xy -9.398 -3.302)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -9.398 -4.318)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -8.89 0) (xy -12.7 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -8.89 0) (xy -8.382 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(rectangle
+				(start -8.382 0.508)
+				(end -6.096 -0.508)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.588 1.778) (xy -5.08 1.016) (xy -4.572 1.778) (xy -5.588 1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.588 1.27) (xy -5.588 1.016) (xy -4.572 1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.588 -2.54) (xy -5.08 -3.302) (xy -4.572 -2.54) (xy -5.588 -2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.588 -3.048) (xy -5.588 -3.302) (xy -4.572 -3.302)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 4.318) (xy 0 4.318)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -5.08 0)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 0) (xy -6.096 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 0) (xy -5.08 4.318)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 -4.064) (xy -5.08 0.254)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center -5.08 -4.318)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.572 3.048) (xy -4.572 3.302) (xy -5.588 3.302)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.572 2.54) (xy -5.08 3.302) (xy -5.588 2.54) (xy -4.572 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.572 -1.27) (xy -4.572 -1.016) (xy -5.588 -1.016)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.572 -1.778) (xy -5.08 -1.016) (xy -5.588 -1.778) (xy -4.572 -1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy -2.286 2.032) (xy -2.286 -2.032)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -2.286 0) (xy -5.08 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 2.286) (xy -1.778 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 0.508) (xy -1.778 -0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 -1.27) (xy -1.778 -2.286)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.778 -1.778) (xy 0.762 -1.778) (xy 0.762 1.778) (xy -1.778 1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.524 0) (xy -0.508 0.381) (xy -0.508 -0.381) (xy -1.524 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 5.08) (xy 0 1.778)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 0 4.318)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 0 1.778)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 0 -1.778)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 0 -4.318)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -5.08) (xy 0 0) (xy -1.778 0)
 				)
 				(stroke
 					(width 0)
@@ -15825,8 +16565,8 @@
 		)
 		(symbol "SZNUD3124LT1G_1_1"
 			(rectangle
-				(start -17.78 7.62)
-				(end 2.54 -7.62)
+				(start -12.7 5.08)
+				(end 1.524 -5.08)
 				(stroke
 					(width 0)
 					(type solid)
@@ -15836,7 +16576,7 @@
 				)
 			)
 			(pin input line
-				(at -20.32 0 0)
+				(at -15.24 0 0)
 				(length 2.54)
 				(name "~"
 					(effects
@@ -15854,7 +16594,7 @@
 				)
 			)
 			(pin unspecified line
-				(at 0 10.16 270)
+				(at 0 7.62 270)
 				(length 2.54)
 				(name "~"
 					(effects
@@ -15872,7 +16612,7 @@
 				)
 			)
 			(pin unspecified line
-				(at 0 -10.16 90)
+				(at 0 -7.62 90)
 				(length 2.54)
 				(name "~"
 					(effects

--- a/Libraries/formula_slug_symbol_library.kicad_sym
+++ b/Libraries/formula_slug_symbol_library.kicad_sym
@@ -1074,6 +1074,922 @@
 		)
 		(embedded_fonts no)
 	)
+	(symbol "BME688"
+		(pin_names
+			(offset 1.016)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at -10.16 10.668 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+				(hide yes)
+			)
+		)
+		(property "Value" "BME688"
+			(at -12.192 -12.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Package_LGA:Bosch_LGA-8_3x3mm_P0.8mm_ClockwisePinNumbering"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify bottom)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme688-ds000.pdf"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "PARTREV" "1.0"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify bottom)
+				(hide yes)
+			)
+		)
+		(property "STANDARD" "Manufacturer recommendations"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify bottom)
+				(hide yes)
+			)
+		)
+		(property "MAXIMUM_PACKAGE_HEIGHT" "1.0 mm"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify bottom)
+				(hide yes)
+			)
+		)
+		(property "Digi PN" "828-BME688CT-ND"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Digi URL" "https://www.digikey.com/en/products/detail/bosch-sensortec/BME688/13681261"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG" "Bosch"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG PN" "BME688"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "BME688_0_1"
+			(rectangle
+				(start -10.16 10.16)
+				(end 10.16 -10.16)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "BME688_1_1"
+			(pin power_in line
+				(at -2.54 15.24 270)
+				(length 5.08)
+				(name "VDDIO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -2.54 -15.24 90)
+				(length 5.08)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 2.54 15.24 270)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 2.54 -15.24 90)
+				(length 5.08)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 15.24 7.62 180)
+				(length 5.08)
+				(name "SDO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 15.24 2.54 180)
+				(length 5.08)
+				(name "SCK"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 15.24 -2.54 180)
+				(length 5.08)
+				(name "SDI"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 15.24 -7.62 180)
+				(length 5.08)
+				(name "CSB"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "BNO086"
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0.254 25.4 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "BNO086"
+			(at 0.254 22.86 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "LGA-28_CEV"
+			(at -25.4 15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://mm.digikey.com/Volume0/opasdata/d220001/medias/docus/6531/BNO080_085_Datasheet-3196201.pdf"
+			(at -25.4 15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Digi URL" "https://www.digikey.com/en/products/detail/ceva-technologies-inc/BNO086/14114190"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG" "CEVA"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG PN" "BNO086"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Digi PN" "1888-BNO086CT-ND"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "BNO086"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "LGA-28_CEV"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "BNO086_1_1"
+			(rectangle
+				(start -17.78 20.32)
+				(end 19.05 -20.32)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -25.4 15.24 0)
+				(length 7.62)
+				(name "BOOTN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -25.4 12.7 0)
+				(length 7.62)
+				(name "CLKSEL0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -25.4 10.16 0)
+				(length 7.62)
+				(name "H_CSN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -25.4 7.62 0)
+				(length 7.62)
+				(name "NRST"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -25.4 2.54 0)
+				(length 7.62)
+				(name "PS0/WAKE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -25.4 -5.08 0)
+				(length 7.62)
+				(name "H_SCL/SCK/RX"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -25.4 -10.16 0)
+				(length 7.62)
+				(name "SA0/H_MOSI"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -25.4 -15.24 0)
+				(length 7.62)
+				(name "H_SDA/H_MISO/TX"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -7.62 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -5.08 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -2.54 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 0 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 2.54 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 5.08 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 7.62 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 10.16 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 12.7 -27.94 90)
+				(length 7.62)
+				(hide yes)
+				(name "RESV_NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 26.67 16.51 180)
+				(length 7.62)
+				(name "H_INTN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 26.67 12.7 180)
+				(length 7.62)
+				(name "XOUT32/CLKSEL1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 26.67 10.16 180)
+				(length 7.62)
+				(name "ENV_SCL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 26.67 7.62 180)
+				(length 7.62)
+				(name "ENV_SDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 26.67 5.08 180)
+				(length 7.62)
+				(name "XIN32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 26.67 1.27 180)
+				(length 7.62)
+				(name "PS1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 26.67 -1.27 180)
+				(length 7.62)
+				(name "VDDIO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 26.67 -3.81 180)
+				(length 7.62)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at 26.67 -8.89 180)
+				(length 7.62)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at 26.67 -11.43 180)
+				(length 7.62)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 26.67 -16.51 180)
+				(length 7.62)
+				(name "CAP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
 	(symbol "BSS308PE"
 		(pin_numbers
 			(hide yes)
@@ -14260,6 +15176,181 @@
 					)
 				)
 				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "SZNUD3124LT1G"
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 0.508 8.382 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SZNUD3124LT1G"
+			(at 0.508 5.842 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:TSOT-23_HandSoldering"
+			(at -12.7 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pdf/datasheet/nud3124-d.pdf"
+			(at -12.7 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Digi PN" "SZNUD3124LT1GOSCT-ND"
+			(at -12.7 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Digi URL" "https://www.digikey.com/en/products/detail/onsemi/SZNUD3124LT1G/3063416"
+			(at -12.7 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG" "onsemi"
+			(at -12.7 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "MFG PN" "SZNUD3124LT1G"
+			(at -12.7 -1.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "SZNUD3124LT1G"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_fp_filters" "SOT-23_TO-236_318_AT_OSI SOT-23_TO-236_318_AT_OSI-M SOT-23_TO-236_318_AT_OSI-L"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "SZNUD3124LT1G_1_1"
+			(rectangle
+				(start -5.08 2.54)
+				(end 2.54 -2.54)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -8.89 0 0)
+				(length 3.81)
+				(name "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin unspecified line
+				(at 6.35 1.27 180)
+				(length 3.81)
+				(name "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin unspecified line
+				(at 6.35 -1.27 180)
+				(length 3.81)
+				(name "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
 					(effects
 						(font
 							(size 1.27 1.27)

--- a/Libraries/formula_slug_symbol_library.kicad_sym
+++ b/Libraries/formula_slug_symbol_library.kicad_sym
@@ -15286,7 +15286,7 @@
 		(symbol "SZNUD3124DMT1G_0_1"
 			(polyline
 				(pts
-					(xy -11.684 -2.54) (xy -11.176 -3.302) (xy -10.668 -2.54) (xy -11.684 -2.54)
+					(xy -9.652 -2.54) (xy -9.144 -3.302) (xy -8.636 -2.54) (xy -9.652 -2.54)
 				)
 				(stroke
 					(width 0)
@@ -15298,7 +15298,7 @@
 			)
 			(polyline
 				(pts
-					(xy -11.684 -3.048) (xy -11.684 -3.302) (xy -10.668 -3.302)
+					(xy -9.652 -3.048) (xy -9.652 -3.302) (xy -8.636 -3.302)
 				)
 				(stroke
 					(width 0)
@@ -15309,7 +15309,7 @@
 				)
 			)
 			(circle
-				(center -11.176 0)
+				(center -9.144 0)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15321,7 +15321,7 @@
 			)
 			(polyline
 				(pts
-					(xy -11.176 -4.318) (xy -11.176 0)
+					(xy -9.144 -4.318) (xy -9.144 0)
 				)
 				(stroke
 					(width 0)
@@ -15333,7 +15333,7 @@
 			)
 			(polyline
 				(pts
-					(xy -11.176 -4.318) (xy 0 -4.318)
+					(xy -9.144 -4.318) (xy 0 -4.318)
 				)
 				(stroke
 					(width 0)
@@ -15345,7 +15345,7 @@
 			)
 			(polyline
 				(pts
-					(xy -10.668 -1.27) (xy -10.668 -1.016) (xy -11.684 -1.016)
+					(xy -8.636 -1.27) (xy -8.636 -1.016) (xy -9.652 -1.016)
 				)
 				(stroke
 					(width 0)
@@ -15357,7 +15357,7 @@
 			)
 			(polyline
 				(pts
-					(xy -10.668 -1.778) (xy -11.176 -1.016) (xy -11.684 -1.778) (xy -10.668 -1.778)
+					(xy -8.636 -1.778) (xy -9.144 -1.016) (xy -9.652 -1.778) (xy -8.636 -1.778)
 				)
 				(stroke
 					(width 0)
@@ -15368,8 +15368,8 @@
 				)
 			)
 			(rectangle
-				(start -9.906 -1.016)
-				(end -8.89 -3.302)
+				(start -8.128 -1.016)
+				(end -7.112 -3.302)
 				(stroke
 					(width 0.2032)
 					(type default)
@@ -15378,8 +15378,20 @@
 					(type none)
 				)
 			)
+			(polyline
+				(pts
+					(xy -7.874 0) (xy -10.16 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
 			(circle
-				(center -9.398 0)
+				(center -7.62 0)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15391,19 +15403,7 @@
 			)
 			(polyline
 				(pts
-					(xy -9.398 0) (xy -9.398 -1.016)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -9.398 -4.064) (xy -9.398 -3.302)
+					(xy -7.62 0) (xy -7.62 -1.016)
 				)
 				(stroke
 					(width 0)
@@ -15414,7 +15414,7 @@
 				)
 			)
 			(circle
-				(center -9.398 -4.318)
+				(center -7.62 -4.318)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15426,7 +15426,7 @@
 			)
 			(polyline
 				(pts
-					(xy -8.89 0) (xy -12.7 0)
+					(xy -7.62 -4.318) (xy -7.62 -3.302)
 				)
 				(stroke
 					(width 0)
@@ -15438,7 +15438,7 @@
 			)
 			(polyline
 				(pts
-					(xy -8.89 0) (xy -8.382 0)
+					(xy -7.366 0) (xy -6.604 0)
 				)
 				(stroke
 					(width 0)
@@ -15449,8 +15449,8 @@
 				)
 			)
 			(rectangle
-				(start -8.382 0.508)
-				(end -6.096 -0.508)
+				(start -6.604 0.508)
+				(end -4.318 -0.508)
 				(stroke
 					(width 0.2032)
 					(type default)
@@ -15461,7 +15461,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 1.778) (xy -5.08 1.016) (xy -4.572 1.778) (xy -5.588 1.778)
+					(xy -3.81 1.778) (xy -3.302 1.016) (xy -2.794 1.778) (xy -3.81 1.778)
 				)
 				(stroke
 					(width 0)
@@ -15473,7 +15473,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 1.27) (xy -5.588 1.016) (xy -4.572 1.016)
+					(xy -3.81 1.27) (xy -3.81 1.016) (xy -2.794 1.016)
 				)
 				(stroke
 					(width 0)
@@ -15485,7 +15485,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 -2.54) (xy -5.08 -3.302) (xy -4.572 -2.54) (xy -5.588 -2.54)
+					(xy -3.81 -2.54) (xy -3.302 -3.302) (xy -2.794 -2.54) (xy -3.81 -2.54)
 				)
 				(stroke
 					(width 0)
@@ -15497,7 +15497,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 -3.048) (xy -5.588 -3.302) (xy -4.572 -3.302)
+					(xy -3.81 -3.048) (xy -3.81 -3.302) (xy -2.794 -3.302)
 				)
 				(stroke
 					(width 0)
@@ -15509,7 +15509,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 4.318) (xy 0 4.318)
+					(xy -3.302 4.318) (xy 0 4.318)
 				)
 				(stroke
 					(width 0)
@@ -15520,7 +15520,7 @@
 				)
 			)
 			(circle
-				(center -5.08 0)
+				(center -3.302 0)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15532,7 +15532,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 0) (xy -6.096 0)
+					(xy -3.302 0) (xy -3.302 4.318)
 				)
 				(stroke
 					(width 0)
@@ -15544,19 +15544,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 0) (xy -5.08 4.318)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -5.08 -4.064) (xy -5.08 0.254)
+					(xy -3.302 -4.064) (xy -3.302 0.254)
 				)
 				(stroke
 					(width 0)
@@ -15567,7 +15555,7 @@
 				)
 			)
 			(circle
-				(center -5.08 -4.318)
+				(center -3.302 -4.318)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -15579,7 +15567,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 3.048) (xy -4.572 3.302) (xy -5.588 3.302)
+					(xy -2.794 3.048) (xy -2.794 3.302) (xy -3.81 3.302)
 				)
 				(stroke
 					(width 0)
@@ -15591,7 +15579,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 2.54) (xy -5.08 3.302) (xy -5.588 2.54) (xy -4.572 2.54)
+					(xy -2.794 2.54) (xy -3.302 3.302) (xy -3.81 2.54) (xy -2.794 2.54)
 				)
 				(stroke
 					(width 0)
@@ -15603,7 +15591,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 -1.27) (xy -4.572 -1.016) (xy -5.588 -1.016)
+					(xy -2.794 -1.27) (xy -2.794 -1.016) (xy -3.81 -1.016)
 				)
 				(stroke
 					(width 0)
@@ -15615,7 +15603,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 -1.778) (xy -5.08 -1.016) (xy -5.588 -1.778) (xy -4.572 -1.778)
+					(xy -2.794 -1.778) (xy -3.302 -1.016) (xy -3.81 -1.778) (xy -2.794 -1.778)
 				)
 				(stroke
 					(width 0)
@@ -15627,19 +15615,7 @@
 			)
 			(polyline
 				(pts
-					(xy -2.286 2.032) (xy -2.286 -2.032)
-				)
-				(stroke
-					(width 0.254)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -2.286 0) (xy -5.08 0)
+					(xy -2.286 0) (xy -4.318 0)
 				)
 				(stroke
 					(width 0)
@@ -15804,7 +15780,7 @@
 		)
 		(symbol "SZNUD3124DMT1G_1_1"
 			(rectangle
-				(start -12.7 5.08)
+				(start -10.16 5.08)
 				(end 1.524 -5.08)
 				(stroke
 					(width 0)
@@ -15814,8 +15790,20 @@
 					(type background)
 				)
 			)
+			(polyline
+				(pts
+					(xy -2.286 2.032) (xy -2.286 -2.032)
+				)
+				(stroke
+					(width 0.2032)
+					(type solid)
+				)
+				(fill
+					(type none)
+				)
+			)
 			(pin input line
-				(at -15.24 0 0)
+				(at -12.7 0 0)
 				(length 2.54)
 				(name "~"
 					(effects
@@ -15871,7 +15859,7 @@
 		)
 		(symbol "SZNUD3124DMT1G_2_1"
 			(rectangle
-				(start -12.7 5.08)
+				(start -10.16 5.08)
 				(end 1.524 -5.08)
 				(stroke
 					(width 0)
@@ -15882,7 +15870,7 @@
 				)
 			)
 			(pin input line
-				(at -15.24 0 0)
+				(at -12.7 0 0)
 				(length 2.54)
 				(name "~"
 					(effects
@@ -16047,7 +16035,7 @@
 		(symbol "SZNUD3124LT1G_0_1"
 			(polyline
 				(pts
-					(xy -11.684 -2.54) (xy -11.176 -3.302) (xy -10.668 -2.54) (xy -11.684 -2.54)
+					(xy -9.652 -2.54) (xy -9.144 -3.302) (xy -8.636 -2.54) (xy -9.652 -2.54)
 				)
 				(stroke
 					(width 0)
@@ -16059,7 +16047,7 @@
 			)
 			(polyline
 				(pts
-					(xy -11.684 -3.048) (xy -11.684 -3.302) (xy -10.668 -3.302)
+					(xy -9.652 -3.048) (xy -9.652 -3.302) (xy -8.636 -3.302)
 				)
 				(stroke
 					(width 0)
@@ -16070,7 +16058,7 @@
 				)
 			)
 			(circle
-				(center -11.176 0)
+				(center -9.144 0)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -16082,7 +16070,7 @@
 			)
 			(polyline
 				(pts
-					(xy -11.176 -4.318) (xy -11.176 0)
+					(xy -9.144 -4.318) (xy -9.144 0)
 				)
 				(stroke
 					(width 0)
@@ -16094,7 +16082,7 @@
 			)
 			(polyline
 				(pts
-					(xy -11.176 -4.318) (xy 0 -4.318)
+					(xy -9.144 -4.318) (xy 0 -4.318)
 				)
 				(stroke
 					(width 0)
@@ -16106,7 +16094,7 @@
 			)
 			(polyline
 				(pts
-					(xy -10.668 -1.27) (xy -10.668 -1.016) (xy -11.684 -1.016)
+					(xy -8.636 -1.27) (xy -8.636 -1.016) (xy -9.652 -1.016)
 				)
 				(stroke
 					(width 0)
@@ -16118,7 +16106,7 @@
 			)
 			(polyline
 				(pts
-					(xy -10.668 -1.778) (xy -11.176 -1.016) (xy -11.684 -1.778) (xy -10.668 -1.778)
+					(xy -8.636 -1.778) (xy -9.144 -1.016) (xy -9.652 -1.778) (xy -8.636 -1.778)
 				)
 				(stroke
 					(width 0)
@@ -16129,8 +16117,8 @@
 				)
 			)
 			(rectangle
-				(start -9.906 -1.016)
-				(end -8.89 -3.302)
+				(start -8.128 -1.016)
+				(end -7.112 -3.302)
 				(stroke
 					(width 0.2032)
 					(type default)
@@ -16139,8 +16127,20 @@
 					(type none)
 				)
 			)
+			(polyline
+				(pts
+					(xy -7.874 0) (xy -10.16 0)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
 			(circle
-				(center -9.398 0)
+				(center -7.62 0)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -16152,19 +16152,7 @@
 			)
 			(polyline
 				(pts
-					(xy -9.398 0) (xy -9.398 -1.016)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -9.398 -4.064) (xy -9.398 -3.302)
+					(xy -7.62 0) (xy -7.62 -1.016)
 				)
 				(stroke
 					(width 0)
@@ -16175,7 +16163,7 @@
 				)
 			)
 			(circle
-				(center -9.398 -4.318)
+				(center -7.62 -4.318)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -16187,7 +16175,7 @@
 			)
 			(polyline
 				(pts
-					(xy -8.89 0) (xy -12.7 0)
+					(xy -7.62 -4.318) (xy -7.62 -3.302)
 				)
 				(stroke
 					(width 0)
@@ -16199,7 +16187,7 @@
 			)
 			(polyline
 				(pts
-					(xy -8.89 0) (xy -8.382 0)
+					(xy -7.366 0) (xy -6.604 0)
 				)
 				(stroke
 					(width 0)
@@ -16210,8 +16198,8 @@
 				)
 			)
 			(rectangle
-				(start -8.382 0.508)
-				(end -6.096 -0.508)
+				(start -6.604 0.508)
+				(end -4.318 -0.508)
 				(stroke
 					(width 0.2032)
 					(type default)
@@ -16222,7 +16210,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 1.778) (xy -5.08 1.016) (xy -4.572 1.778) (xy -5.588 1.778)
+					(xy -3.81 1.778) (xy -3.302 1.016) (xy -2.794 1.778) (xy -3.81 1.778)
 				)
 				(stroke
 					(width 0)
@@ -16234,7 +16222,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 1.27) (xy -5.588 1.016) (xy -4.572 1.016)
+					(xy -3.81 1.27) (xy -3.81 1.016) (xy -2.794 1.016)
 				)
 				(stroke
 					(width 0)
@@ -16246,7 +16234,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 -2.54) (xy -5.08 -3.302) (xy -4.572 -2.54) (xy -5.588 -2.54)
+					(xy -3.81 -2.54) (xy -3.302 -3.302) (xy -2.794 -2.54) (xy -3.81 -2.54)
 				)
 				(stroke
 					(width 0)
@@ -16258,7 +16246,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.588 -3.048) (xy -5.588 -3.302) (xy -4.572 -3.302)
+					(xy -3.81 -3.048) (xy -3.81 -3.302) (xy -2.794 -3.302)
 				)
 				(stroke
 					(width 0)
@@ -16270,7 +16258,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 4.318) (xy 0 4.318)
+					(xy -3.302 4.318) (xy 0 4.318)
 				)
 				(stroke
 					(width 0)
@@ -16281,7 +16269,7 @@
 				)
 			)
 			(circle
-				(center -5.08 0)
+				(center -3.302 0)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -16293,7 +16281,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 0) (xy -6.096 0)
+					(xy -3.302 0) (xy -3.302 4.318)
 				)
 				(stroke
 					(width 0)
@@ -16305,19 +16293,7 @@
 			)
 			(polyline
 				(pts
-					(xy -5.08 0) (xy -5.08 4.318)
-				)
-				(stroke
-					(width 0)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -5.08 -4.064) (xy -5.08 0.254)
+					(xy -3.302 -4.064) (xy -3.302 0.254)
 				)
 				(stroke
 					(width 0)
@@ -16328,7 +16304,7 @@
 				)
 			)
 			(circle
-				(center -5.08 -4.318)
+				(center -3.302 -4.318)
 				(radius 0.254)
 				(stroke
 					(width 0)
@@ -16340,7 +16316,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 3.048) (xy -4.572 3.302) (xy -5.588 3.302)
+					(xy -2.794 3.048) (xy -2.794 3.302) (xy -3.81 3.302)
 				)
 				(stroke
 					(width 0)
@@ -16352,7 +16328,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 2.54) (xy -5.08 3.302) (xy -5.588 2.54) (xy -4.572 2.54)
+					(xy -2.794 2.54) (xy -3.302 3.302) (xy -3.81 2.54) (xy -2.794 2.54)
 				)
 				(stroke
 					(width 0)
@@ -16364,7 +16340,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 -1.27) (xy -4.572 -1.016) (xy -5.588 -1.016)
+					(xy -2.794 -1.27) (xy -2.794 -1.016) (xy -3.81 -1.016)
 				)
 				(stroke
 					(width 0)
@@ -16376,7 +16352,7 @@
 			)
 			(polyline
 				(pts
-					(xy -4.572 -1.778) (xy -5.08 -1.016) (xy -5.588 -1.778) (xy -4.572 -1.778)
+					(xy -2.794 -1.778) (xy -3.302 -1.016) (xy -3.81 -1.778) (xy -2.794 -1.778)
 				)
 				(stroke
 					(width 0)
@@ -16388,19 +16364,7 @@
 			)
 			(polyline
 				(pts
-					(xy -2.286 2.032) (xy -2.286 -2.032)
-				)
-				(stroke
-					(width 0.254)
-					(type default)
-				)
-				(fill
-					(type none)
-				)
-			)
-			(polyline
-				(pts
-					(xy -2.286 0) (xy -5.08 0)
+					(xy -2.286 0) (xy -4.318 0)
 				)
 				(stroke
 					(width 0)
@@ -16565,7 +16529,7 @@
 		)
 		(symbol "SZNUD3124LT1G_1_1"
 			(rectangle
-				(start -12.7 5.08)
+				(start -10.16 5.08)
 				(end 1.524 -5.08)
 				(stroke
 					(width 0)
@@ -16575,8 +16539,20 @@
 					(type background)
 				)
 			)
+			(polyline
+				(pts
+					(xy -2.286 2.032) (xy -2.286 -2.032)
+				)
+				(stroke
+					(width 0.2032)
+					(type solid)
+				)
+				(fill
+					(type none)
+				)
+			)
 			(pin input line
-				(at -15.24 0 0)
+				(at -12.7 0 0)
 				(length 2.54)
 				(name "~"
 					(effects


### PR DESCRIPTION
# Changes
* Made SZNUD3124LT1G symbol more compact:
Before:
<img width="754" height="697" alt="image" src="https://github.com/user-attachments/assets/8b4ef32c-d259-4864-9147-a9fdff1bc905" />

After:
<img width="754" height="697" alt="image" src="https://github.com/user-attachments/assets/a7c05016-7193-433c-a865-9be191464a37" />

* Added symbol for dual variant (SZNUD3124DMT1G)

# Areas to review
* Check pins on SZNUD3124DMT1G
* Check footprint for SZNUD3124DMT1G

# Things not to review
* if you make a single comment on the graphical symbol i'll kill you (no i wont)